### PR TITLE
Fix git-solana path in setup script

### DIFF
--- a/server/src/utils/setup-solana.js
+++ b/server/src/utils/setup-solana.js
@@ -22,7 +22,17 @@ function checkTestValidator() {
 
 // Check if Anchor program has been built
 function checkAnchorBuild() {
-  const targetDir = path.join(__dirname, '..', 'git-solana', 'target');
+  // The git-solana directory lives three levels up from this script
+  // (server/src/utils). Using fewer ".." would resolve to
+  // server/git-solana, which does not exist.
+  const targetDir = path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'git-solana',
+    'target'
+  );
   if (!fs.existsSync(targetDir)) {
     console.error('❌ Anchor build directory not found');
     console.log('Run the following commands:');
@@ -49,17 +59,19 @@ function checkAnchorBuild() {
 function deployProgram() {
   try {
     console.log('Deploying program to localnet...');
-    
+
     // Change to the git-solana directory
-    process.chdir(path.join(__dirname, '..', 'git-solana'));
-    
+    // The path is three levels up from this script (server/src/utils)
+    const originalDir = process.cwd();
+    process.chdir(path.join(__dirname, '..', '..', '..', 'git-solana'));
+
     // Deploy the program
     execSync('anchor deploy', { stdio: 'inherit' });
     
     console.log('✅ Program deployed successfully');
     
-    // Change back to the server directory
-    process.chdir(path.join(__dirname));
+    // Change back to the original directory (server root)
+    process.chdir(originalDir);
     
     return true;
   } catch (error) {

--- a/server/src/utils/solanaClient.js
+++ b/server/src/utils/solanaClient.js
@@ -12,18 +12,40 @@ const bs58 = require('bs58');
 // We'll use this to interact with the program if available
 let idl = null;
 const idlPaths = [
-  path.join(__dirname, '..', 'git-solana', 'target', 'idl', 'git_solana.json'),
-  path.join(__dirname, '..', '..', '..', 'git-solana', 'target', 'idl', 'git_solana.json'),
-  path.join(__dirname, '..', '..', '..', 'git-solana', 'target', 'types', 'git_solana.ts')
+  // git-solana directory lives three levels up from this file (server/src/utils)
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'git-solana',
+    'target',
+    'idl',
+    'git_solana.json'
+  ),
+  path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'git-solana',
+    'target',
+    'types',
+    'git_solana.ts'
+  )
 ];
 
 for (const idlPath of idlPaths) {
   try {
     idl = JSON.parse(fs.readFileSync(idlPath, 'utf8'));
+    if (!idl.accounts) {
+      throw new Error('IDL missing accounts');
+    }
     console.log(`Loaded git-solana IDL from ${idlPath}`);
     break;
   } catch (err) {
-    // Continue to the next path
+    // Continue to the next path if file not found or invalid
+    console.warn(`Failed to load IDL from ${idlPath}: ${err.message}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- point setup script to correct `git-solana` directory
- restore working directory after deploy
- validate IDL contents when loading and warn if missing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f4e9dda008324bcd6e67cc2a3ae44